### PR TITLE
Support building qBittorrent 4.5.0

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        QBITTORRENT_VER: [ "master", "v4_4_x", "v4_3_x" ]
+        QBITTORRENT_VER: [ "master", "v4_5_x", "v4_4_x", "v4_3_x" ]
         QBITTORRENT_BUILD_TYPE: [ "release", "debug" ]
         LIBTORRENT_VER: [ "${{ needs.setup.outputs.libtorrent-v2-version }}", "${{ needs.setup.outputs.libtorrent-v1-version }}" ]
         include:

--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Declare qBittorrent Versions
         id: set-qbittorrent-versions
         run: |  # find all releases >= v4.3.0
-          VERS=$( \
+          ALL_VERS=$( \
             git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/qbittorrent/qBittorrent.git | \
             cut --delimiter='/' --fields=3 | \
             grep -v "\^{}" | \
@@ -43,11 +43,20 @@ jobs:
             grep '^4\.[3-9]\.\d*.' \
           )
 
-          LATEST_VER=$(echo ${VERS} | rev | cut -d' ' -f1 | rev)
+          FINAL_VERSION_VERS=$( \
+            git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/qbittorrent/qBittorrent.git | \
+            grep -vE 'beta|rc' | \
+            cut --delimiter='/' --fields=3 | \
+            grep -v "\^{}" | \
+            cut --delimiter='-' --fields=2 | \
+            grep '^4\.[3-9]\.\d*.' \
+          )
+
+          LATEST_VER=$(echo ${FINAL_VERSION_VERS} | rev | cut -d' ' -f1 | rev)
           echo "Latest: ${LATEST_VER}"
           echo "qbittorrent-latest-version=${LATEST_VER}" >> ${GITHUB_OUTPUT}
 
-          VERS_MATRIX_LIST=$(echo ${VERS} | sed -z 's/ /","/g;s/,$/\n/')
+          VERS_MATRIX_LIST=$(echo ${ALL_VERS} | sed -z 's/ /","/g;s/,$/\n/')
           VERS_MATRIX_LIST="[\"${VERS_MATRIX_LIST}\"]"
           echo ${VERS_MATRIX_LIST}
           echo "qbittorrent-versions=${VERS_MATRIX_LIST}" >> ${GITHUB_OUTPUT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,16 +78,17 @@ WORKDIR "${BASEPATH}"
 ARG CACHEBUST=1
 ARG QBT_VERSION
 RUN echo ${CACHEBUST} && \
-    if [[ "${QBT_VERSION}" = "master" ]] ; then \
-      QBT_DIR="qBittorrent-${QBT_VERSION}" && \
-      QBT_URL="https://github.com/qbittorrent/qBittorrent/archive/refs/heads/${QBT_VERSION}.tar.gz" ; \
-    elif [[ "${QBT_VERSION}" = "v4_4_x" || "${QBT_VERSION}" = "v4_3_x" ]] ; then \
-      QBT_DIR="qBittorrent-${QBT_VERSION:1}" && \
-      QBT_URL="https://github.com/qbittorrent/qBittorrent/archive/refs/heads/${QBT_VERSION}.tar.gz" ; \
-    else \
-      QBT_DIR="qBittorrent-release-${QBT_VERSION}" && \
-      QBT_URL="https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-${QBT_VERSION}.tar.gz" ; \
-    fi && \
+    case ${QBT_VERSION} in \
+      master) \
+        QBT_DIR="qBittorrent-${QBT_VERSION}" && \
+        QBT_URL="https://github.com/qbittorrent/qBittorrent/archive/refs/heads/${QBT_VERSION}.tar.gz" ;; \
+      v4_5_x |v4_4_x | v4_3_x) \
+        QBT_DIR="qBittorrent-${QBT_VERSION:1}" && \
+        QBT_URL="https://github.com/qbittorrent/qBittorrent/archive/refs/heads/${QBT_VERSION}.tar.gz" ;; \
+      *) \
+        QBT_DIR="qBittorrent-release-${QBT_VERSION}" && \
+        QBT_URL="https://github.com/qbittorrent/qBittorrent/archive/refs/tags/release-${QBT_VERSION}.tar.gz" ;; \
+    esac && \
     curl -sNLk ${QBT_URL} | tar -zxf - -C "${BASEPATH}" && \
     mv "${BASEPATH}/${QBT_DIR}" "${BASEPATH}/qBittorrent"
 # https://github.com/qbittorrent/qBittorrent/issues/13981#issuecomment-746836281


### PR DESCRIPTION
- Support building from `v4_5_x` branch
- Exclude pre-releases from having the `latest` tag applied to them