### PR TITLE
Export images to Docker for post-build handling

### DIFF
--- a/.github/workflows/docker-publish-all.yml
+++ b/.github/workflows/docker-publish-all.yml
@@ -18,7 +18,6 @@ on:
 env:
   REGISTRY: ghcr.io
   REGISTRY_USER: rmartin16
-  CACHE_VER: "1"
 
 jobs:
 
@@ -100,8 +99,7 @@ jobs:
             type=raw,value=libtorrent-${{ matrix.LIBTORRENT_TAG }}
             type=raw,value=latest,enable=${{ matrix.LIBTORRENT_VER == needs.setup.outputs.libtorrent-v2-version }}
 
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build image
         uses: docker/build-push-action@v3
         with:
           file: All.Dockerfile
@@ -113,18 +111,15 @@ jobs:
           build-args: LIBTORRENT_VERSION=${{ matrix.LIBTORRENT_VER }}
 
       - name: Save image to file
-        id: save-image
         run: docker save -o /tmp/base-image.tar ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/qbittorrent-base
 
-      - name: Upload base image as artifact
-        id: upload-base-image
+      - name: Upload image as artifact
         uses: actions/upload-artifact@v3
         with:
           name: base-image-libtorrent-${{ matrix.LIBTORRENT_TAG }}
           path: /tmp/base-image.tar
 
-      - name: Publish to ghcr.io
-        id: publish
+      - name: Publish image to ghcr.io
         if: github.event_name != 'pull_request'
         run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/qbittorrent-base
 
@@ -173,8 +168,7 @@ jobs:
           tags: |
             type=raw,value=legacy-libtorrent-${{ matrix.LIBTORRENT_TAG }}
 
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build image
         uses: docker/build-push-action@v3
         with:
           file: All.Legacy.Dockerfile
@@ -186,18 +180,15 @@ jobs:
           build-args: LIBTORRENT_VERSION=${{ matrix.LIBTORRENT_VER }}
 
       - name: Save image to file
-        id: save-image
         run: docker save -o /tmp/base-image.tar ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/qbittorrent-base
 
       - name: Upload image as artifact
-        id: upload-base-image
         uses: actions/upload-artifact@v3
         with:
           name: base-image-legacy-libtorrent-${{ matrix.LIBTORRENT_TAG }}
           path: /tmp/base-image.tar
 
       - name: Publish image to ghcr.io
-        id: publish
         if: github.event_name != 'pull_request'
         run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/qbittorrent-base
 

--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -15,7 +15,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: rmartin16/qbittorrent-nox
-  CACHE_VER: "1"
 
 jobs:
 
@@ -48,14 +47,14 @@ jobs:
         with:
           driver: docker
 
-      - name: Download artifact
+      - name: Download base image artifact
         uses: actions/download-artifact@v3
         continue-on-error: true
         with:
           name: base-image-libtorrent-${{ matrix.LIBTORRENT_TAG }}
           path: /tmp
 
-      - name: Load Docker image
+      - name: Load base image
         run: |
           if [ -f "/tmp/base-image.tar" ]; then
             docker load --input /tmp/base-image.tar
@@ -96,13 +95,12 @@ jobs:
             # master-v1-debug - specific debug qBittorrent with latest v1 libtorrent
             type=raw,value=${{ matrix.QBITTORRENT_VER }}-v1-debug,enable=${{ matrix.QBITTORRENT_BUILD_TYPE == 'debug' && matrix.LIBTORRENT_TAG == 'v1' }}
 
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build image
         uses: docker/build-push-action@v3
         with:
           file: qBittorrent.Dockerfile
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -112,14 +110,11 @@ jobs:
             QT_VERSION=${{ steps.qt.outputs.version }}
 
       - name: Set up Python
-        if: github.event_name != 'pull_request'
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
       - name: Verify image
-        id: verify
-        if: github.event_name != 'pull_request'
         run: |
           DOCKER_TAG=${{ matrix.QBITTORRENT_VER }}-${{ matrix.LIBTORRENT_TAG }}
           if [[ "${{ matrix.QBITTORRENT_BUILD_TYPE }}" = "debug" ]]; then DOCKER_TAG="${DOCKER_TAG}-debug"; fi
@@ -127,3 +122,7 @@ jobs:
           python -m pip install qbittorrent-api
           docker logs qbt
           python -c 'from qbittorrentapi import Client; client=Client("localhost",8080,"admin","adminadmin"); print(f"{client.app.version=}")'
+
+      - name: Publish image to ghcr.io
+        if: github.event_name != 'pull_request'
+        run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-publish-legacy.yml
+++ b/.github/workflows/docker-publish-legacy.yml
@@ -50,15 +50,14 @@ jobs:
         with:
           driver: docker
 
-      - name: Download artifact
-        id: download-artifact
+      - name: Download base image artifact
         continue-on-error: true
         uses: actions/download-artifact@v3
         with:
           name: base-image-legacy-libtorrent-${{ matrix.LIBTORRENT_TAG }}
           path: /tmp
 
-      - name: Load Docker image
+      - name: Load base image
         run: |
           if [ -f "/tmp/base-image.tar" ]; then
             docker load --input /tmp/base-image.tar
@@ -95,13 +94,12 @@ jobs:
             # v4.2.5-v1-debug - specific debug qBittorrent with specific libtorrent version
             type=raw,value=v${{ matrix.QBITTORRENT_VER }}-v1-debug,enable=${{ matrix.QBITTORRENT_BUILD_TYPE == 'debug' }}
 
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build image
         uses: docker/build-push-action@v3
         with:
           file: qBittorrent.Legacy.Dockerfile
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -110,18 +108,19 @@ jobs:
             QBT_BUILD_TYPE=${{ matrix.QBITTORRENT_BUILD_TYPE }}
 
       - name: Set up Python
-        if: github.event_name != 'pull_request'
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
       - name: Verify image
-        id: verify
-        if: github.event_name != 'pull_request'
         run: |
           DOCKER_TAG=v${{ matrix.QBITTORRENT_VER }}-v1
           if [[ "${{ matrix.QBITTORRENT_BUILD_TYPE }}" = "debug" ]]; then DOCKER_TAG="${DOCKER_TAG}-debug"; fi
           docker run --rm -d --name qbt -p8080:8080 ${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}
           python -m pip install qbittorrent-api
           docker logs qbt
-          python -c 'from qbittorrentapi import Client; client=Client("localhost",8080,"admin","adminadmin"); print(f"{client.app.version=}")'
+          python -c 'from qbittorrentapi import Client; client=Client("localhost",8080,"admin","adminadmin"); print(f"{client.app.version=}"); assert client.app.version=="v${{ matrix.QBITTORRENT_VER }}"'
+
+      - name: Publish image to ghcr.io
+        if: github.event_name != 'pull_request'
+        run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-publish-release.yml
+++ b/.github/workflows/docker-publish-release.yml
@@ -13,7 +13,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: rmartin16/qbittorrent-nox
-  CACHE_VER: "1"
 
 jobs:
 
@@ -84,15 +83,14 @@ jobs:
         with:
           driver: docker
 
-      - name: Download artifact
-        id: download-artifact
+      - name: Download base image artifact
         continue-on-error: true
         uses: actions/download-artifact@v3
         with:
           name: base-image-libtorrent-${{ matrix.LIBTORRENT_TAG }}
           path: /tmp
 
-      - name: Load Docker image
+      - name: Load base image
         run: |
           if [ -f "/tmp/base-image.tar" ]; then
             docker load --input /tmp/base-image.tar
@@ -145,14 +143,13 @@ jobs:
             # v4.4.4-v1-debug - specific debug qBittorrent with latest v1 libtorrent
             type=raw,value=v${{ matrix.QBITTORRENT_VER }}-v1-debug,enable=${{ matrix.QBITTORRENT_BUILD_TYPE == 'debug' && matrix.LIBTORRENT_TAG == 'v1' }}
 
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Build image
         uses: docker/build-push-action@v3
         with:
           file: qBittorrent.Dockerfile
           context: .
           no-cache-filters: release
-          push: ${{ github.event_name != 'pull_request' }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -162,14 +159,11 @@ jobs:
             QT_VERSION=${{ steps.qt.outputs.version }}
 
       - name: Set up Python
-        if: github.event_name != 'pull_request'
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
       - name: Verify image
-        id: verify
-        if: github.event_name != 'pull_request'
         run: |
           DOCKER_TAG=v${{ matrix.QBITTORRENT_VER }}-${{ matrix.LIBTORRENT_TAG }}
           if [[ "${{ matrix.QBITTORRENT_BUILD_TYPE }}" = "debug" ]]; then DOCKER_TAG="${DOCKER_TAG}-debug"; fi
@@ -177,3 +171,7 @@ jobs:
           python -m pip install qbittorrent-api
           docker logs qbt
           python -c 'from qbittorrentapi import Client; client=Client("localhost",8080,"admin","adminadmin"); print(f"{client.app.version=}"); assert client.app.version=="v${{ matrix.QBITTORRENT_VER }}"'
+
+      - name: Publish image to ghcr.io
+        if: github.event_name != 'pull_request'
+        run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
After a lot of fiddling, be98808e277bbfad9ee681adfa4e158fb51b51e4 was able to successfully build the base image, pass it to subsequent builds, _and_ upload the image to ghcr.io outside of PRs.

Following these same principles, the final images are now exported from `buildx` and imported in to the local docker env. This allows the image tests to run for PRs and to upload to ghcr.io outside of PRs.

- Fixes #14 